### PR TITLE
Fix wrong variable being incremented - caused algorithm not to iterate.

### DIFF
--- a/sklearn_cotraining/classifiers.py
+++ b/sklearn_cotraining/classifiers.py
@@ -138,7 +138,7 @@ class CoTrainingClassifier(object):
 			add_counter = 0 #number we have added from U to U_
 			num_to_add = len(p) + len(n)
 			while add_counter != num_to_add and U:
-				num_to_add += 1
+				add_counter += 1
 				U_.append(U.pop())
 
 


### PR DESCRIPTION
I want to use co-training in my master thesis and if I understand it correctly, it should iterate multiple times. The line i changed prevented that from happening, since the condition 'while add_counter != num_to_add' is always True, because 'num_to_add' is being incremented instead of 'add_counter'.